### PR TITLE
remove ca.crt of console header

### DIFF
--- a/stable/console-chart/templates/console-header-deployment.yaml
+++ b/stable/console-chart/templates/console-header-deployment.yaml
@@ -86,15 +86,6 @@ spec:
           items:
           - key: log4js.json
             path: log4js.json
-      - name: cluster-ca
-        secret:
-          defaultMode: 420
-          items:
-          - key: tls.key
-            path: ca.key
-          - key: tls.crt
-            path: ca.crt
-          secretName: multicloud-ca-cert
       terminationGracePeriodSeconds: 60
       tolerations:
       - key: "dedicated"
@@ -139,15 +130,11 @@ spec:
           volumeMounts:
           - name: log4js
             mountPath: /etc/config
-          - mountPath: /opt/app-root/console-header/certs
-            name: cluster-ca
           env:
             - name: headerContextPath
               value: {{ .Values.consoleheader.ingressPath}}
             - name: headerUrl
               value: {{ .Values.cfcRouterUrl }}
-            - name: NODE_EXTRA_CA_CERTS
-              value: /opt/app-root/console-header/certs/ca.crt
             - name: NAV_PORT
               value: "{{ .Values.navPort }}"
             - name: default_admin_user


### PR DESCRIPTION
Signed-off-by: Hanqiu Zhang <hanzhang@redhat.com>

NODE_EXTRA_CA_CERTS is not used in console-header repo, guess we can remove it.
Also seems header is using http instead of https when in cluster 😂 

Issue: https://github.com/open-cluster-management/backlog/issues/11702

Tests:
- [x] header still works for KUI & search when using this chart

Screenshot:
<img width="1435" alt="Screen Shot 2021-04-26 at 12 58 13 PM" src="https://user-images.githubusercontent.com/31426239/116121872-118e3a80-a68f-11eb-8bdb-7cc99242d92d.png">
<img width="1283" alt="Screen Shot 2021-04-26 at 12 58 43 PM" src="https://user-images.githubusercontent.com/31426239/116121947-25d23780-a68f-11eb-95ae-7dcc6db69948.png">
