### PR TITLE
Remove OCP4.5 ClusterImageSet from ACM 2.1.7

### DIFF
--- a/stable/console-chart/templates/img4.5.36-x86_64.yaml
+++ b/stable/console-chart/templates/img4.5.36-x86_64.yaml
@@ -1,9 +1,0 @@
-apiVersion: hive.openshift.io/v1
-kind: ClusterImageSet
-metadata:
-  labels:
-    channel: fast
-    visible: 'true'
-  name: img4.5.36-x86-64-chart
-spec:
-  releaseImage: quay.io/openshift-release-dev/ocp-release:4.5.36-x86_64


### PR DESCRIPTION
Signed-off-by: Joshua Packer <jpacker@redhat.com>

* Remove OCP 4.5 clusterImageSet