### PR TITLE
Add permissions for console to watch CIM resources

### DIFF
--- a/stable/console-chart/templates/console-clusterrole.yaml
+++ b/stable/console-chart/templates/console-clusterrole.yaml
@@ -151,3 +151,20 @@ rules:
   - submarineraddon.open-cluster-management.io
   resources:
   - submarinerconfigs
+  
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - extensions.hive.openshift.io
+  resources:
+  - agentclusterinstalls
+  
+- verbs:
+  - list
+  - watch
+  apiGroups:
+  - agent-install.openshift.io
+  resources:
+  - agents
+  - infraenvs


### PR DESCRIPTION
permissions for these resources are required by Central infrastructure management components from https://github.com/open-cluster-management/console/pull/814