### PR TITLE
Add ConsolePlugin resource

### DIFF
--- a/stable/console-chart/templates/console-link.yaml
+++ b/stable/console-chart/templates/console-link.yaml
@@ -9,5 +9,5 @@ spec:
   location: ApplicationMenu
   text: Red Hat Advanced Cluster Management for Kubernetes
   applicationMenu:
-    section: Red Hat Applications
+    section: Red Hat applications
     imageURL: https://multicloud-console.{{ .Values.ocpingress }}/multicloud/favicon.svg

--- a/stable/console-chart/templates/console-plugin.yaml
+++ b/stable/console-chart/templates/console-plugin.yaml
@@ -1,0 +1,19 @@
+# Copyright Contributors to the Open Cluster Management project
+
+apiVersion: console.openshift.io/v1alpha1
+kind: ConsolePlugin
+metadata:
+  name: acm-console-plugin
+spec:
+  displayName: Red Hat Advanced Cluster Management
+  proxy:
+    services:
+      - authorize: true
+        name: {{ template "console.fullname" . }}-console-v2
+        namespace: {{ .Release.Namespace }}
+        port: 3000
+  service:
+    basePath: /plugin/
+    name: {{ template "console.fullname" . }}-console-v2
+    namespace: {{ .Release.Namespace }}
+    port: 3000

--- a/stable/console-chart/templates/console-plugin.yaml
+++ b/stable/console-chart/templates/console-plugin.yaml
@@ -3,7 +3,7 @@
 apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
 metadata:
-  name: acm-console-plugin
+  name: acm-plugin
 spec:
   displayName: Red Hat Advanced Cluster Management
   proxy:

--- a/stable/console-chart/templates/console-plugin.yaml
+++ b/stable/console-chart/templates/console-plugin.yaml
@@ -1,5 +1,5 @@
 # Copyright Contributors to the Open Cluster Management project
-
+{{ if .Values.plugin }}
 apiVersion: console.openshift.io/v1alpha1
 kind: ConsolePlugin
 metadata:
@@ -17,3 +17,4 @@ spec:
     name: {{ template "console.fullname" . }}-console-v2
     namespace: {{ .Release.Namespace }}
     port: 3000
+{{ end }}

--- a/stable/console-chart/values.yaml
+++ b/stable/console-chart/values.yaml
@@ -28,6 +28,7 @@ cfcRouterUrl: "https://management-ingress:443"
 navPort: 443
 
 enabled: true
+plugin: false
 
 ocpingress: ""
 


### PR DESCRIPTION
Need to install this conditionally on OCP 4.10 and higher. Might be able generate the resource conditionally using `Capabilities.APIVersions.Has console.openshift.io/v1alpha1/ConsolePlugin` however currently the CRD does exist on versions of OCP at least back to 4.7, but up until 4.10, there is no support for `spec.proxy`. I have asked if the CRD version will be bumped [on Slack](https://coreos.slack.com/archives/C011BL0FEKZ/p1637183087236300).

For the moment, controlling installation with the `plugin` boolean in values.yaml.