### PR TITLE
Revert "use release-2.2 branch in clusterimageset subscription (#161)"

### DIFF
--- a/stable/console-chart/templates/subscription-fast.yaml
+++ b/stable/console-chart/templates/subscription-fast.yaml
@@ -5,7 +5,7 @@ apiVersion: apps.open-cluster-management.io/v1
 kind: Subscription
 metadata:
   annotations:
-    apps.open-cluster-management.io/git-branch: release-2.2
+    apps.open-cluster-management.io/git-branch: release-2.5
     apps.open-cluster-management.io/git-path: clusterImageSets/fast
   labels:
     app: hive-clusterimagesets


### PR DESCRIPTION
This reverts commit 67ae348717943c8ed6ba4d8bb0c3413c23ba7ca6.